### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Add below 2 dependency to your project pom.xml file, please refer to the release
 <dependency>
     <groupId>org.rainyheart</groupId>
     <artifactId>distributed-lock-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 </dependency>
 <dependency>
     <groupId>org.rainyheart</groupId>
     <artifactId>distributed-lock-zk-impl</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/distributed-lock-api-facade/pom.xml
+++ b/distributed-lock-api-facade/pom.xml
@@ -7,10 +7,10 @@
 	<parent>
 		<groupId>org.rainyheart</groupId>
 		<artifactId>distributed-lock-projects</artifactId>
-		<version>1.0.0</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
     <artifactId>distributed-lock-api-facade</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>distributed-lock-api-facade</name>
     <url>http://maven.apache.org</url>
     <properties>

--- a/distributed-lock-api/pom.xml
+++ b/distributed-lock-api/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.rainyheart</groupId>
 		<artifactId>distributed-lock-projects</artifactId>
-		<version>1.0.0</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>distributed-lock-api</artifactId>
 	<name>distributed-lock</name>
 	<description>distributed-lock</description>
-	<version>1.0.0</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/distributed-lock-zk-impl/pom.xml
+++ b/distributed-lock-zk-impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.rainyheart</groupId>
         <artifactId>distributed-lock-projects</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>distributed-lock-zk-impl</artifactId>
     <name>distributed-lock-zk-impl</name>
     <description>distributed-lock-zk-impl</description>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/distributed-lock-zk-impl/pom.xml
+++ b/distributed-lock-zk-impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.rainyheart</groupId>
         <artifactId>distributed-lock-projects</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <artifactId>distributed-lock-zk-impl</artifactId>
     <name>distributed-lock-zk-impl</name>
     <description>distributed-lock-zk-impl</description>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
 
     <dependencies>
         <dependency>

--- a/distributed-lock-zk-impl/src/main/java/org/rainyheart/distributed/lock/thridparty/zk/ZooKeeperManager.java
+++ b/distributed-lock-zk-impl/src/main/java/org/rainyheart/distributed/lock/thridparty/zk/ZooKeeperManager.java
@@ -190,7 +190,16 @@ public class ZooKeeperManager implements DistributedLockManager {
                 printOrLog(MSG_UNEXPECTED_EXCEPTION, e);
             }
         } else {
-            printOrLog(path + COMMER + e.getLocalizedMessage(), e);
+            if (e instanceof KeeperException) {
+                Code code = ((KeeperException) e).code();
+                // if it is node exists exception, no need to print logs because it is a very
+                // normal case to fail to get lock
+                if (!code.equals(Code.NODEEXISTS)) {
+                    printOrLog(path + COMMER + e.getLocalizedMessage(), e);
+                }
+            } else {
+                printOrLog(MSG_UNEXPECTED_EXCEPTION, e);
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rainyheart</groupId>
     <artifactId>distributed-lock-projects</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>distributed-lock-projects</name>
     <description>distributed-lock-projects</description>
@@ -42,8 +42,8 @@
         <project.reporting.outputEncoding>utf-8</project.reporting.outputEncoding>
 
         <!-- Project Internal Modules Versions -->
-        <distributed-lock-api.version>1.0.0</distributed-lock-api.version>
-        <distributed-lock-zk-impl.version>1.0.0</distributed-lock-zk-impl.version>
+        <distributed-lock-api.version>1.1.0-SNAPSHOT</distributed-lock-api.version>
+        <distributed-lock-zk-impl.version>1.1.0-SNAPSHOT</distributed-lock-zk-impl.version>
 
         <!-- 3pp versions -->
         <spring.version>5.2.1.RELEASE</spring.version>


### PR DESCRIPTION
Release: distributed-lock-zk-impl：1.1.0
 - Remove unnecessary error logs for the NodeExists error from ZK because it is quite normal when fail to get a lock